### PR TITLE
Make elements clonable.

### DIFF
--- a/src/document_tree/attribute_types.rs
+++ b/src/document_tree/attribute_types.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 
 use crate::target;
 
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)]
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)]
 pub enum EnumeratedListType {
 	Arabic,
 	LowerAlpha,
@@ -15,24 +15,24 @@ pub enum EnumeratedListType {
 	UpperRoman,
 }
 
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)]
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)]
 pub enum FixedSpace { Default, Preserve }  // yes, default really is not “Default”
 impl Default for FixedSpace { fn default() -> FixedSpace { FixedSpace::Preserve } }
 
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub enum AlignH { Left, Center, Right}
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub enum AlignHV { Top, Middle, Bottom, Left, Center, Right }
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub enum AlignV { Top, Middle, Bottom }
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub enum AlignH { Left, Center, Right}
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub enum AlignHV { Top, Middle, Bottom, Left, Center, Right }
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub enum AlignV { Top, Middle, Bottom }
 
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub enum TableAlignH { Left, Right, Center, Justify, Char }
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub enum TableBorder { Top, Bottom, TopBottom, All, Sides, None }
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub enum TableAlignH { Left, Right, Center, Justify, Char }
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub enum TableBorder { Top, Bottom, TopBottom, All, Sides, None }
 
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub struct ID(pub String);
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub struct NameToken(pub String);
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub struct ID(pub String);
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub struct NameToken(pub String);
 
 // The table DTD has the cols attribute of tgroup as required, but having
 // TableGroupCols not implement Default would leave no possible implementation
 // for TableGroup::with_children.
-#[derive(Debug,PartialEq,Eq,Hash,Serialize)] pub struct TableGroupCols(pub usize);
+#[derive(Debug,PartialEq,Eq,Hash,Serialize,Clone)] pub struct TableGroupCols(pub usize);
 impl Default for TableGroupCols {
 	fn default() -> Self {
 		TableGroupCols(0)
@@ -40,7 +40,7 @@ impl Default for TableGroupCols {
 }
 
 // no eq for f64
-#[derive(Debug,PartialEq,Serialize)]
+#[derive(Debug,PartialEq,Serialize,Clone)]
 pub enum Measure {  // http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#length-units
 	Em(f64),
 	Ex(f64),

--- a/src/document_tree/element_categories.rs
+++ b/src/document_tree/element_categories.rs
@@ -43,7 +43,7 @@ macro_rules! synonymous_enum {
 		cartesian!(impl_into, [ $( ($subcat::$entry) ),+ ], [ $($supcat),+ ]);
 	};
 	( $name:ident { $( $entry:ident ),+ $(,)* } ) => {
-		#[derive(PartialEq,Serialize)]
+		#[derive(PartialEq,Serialize,Clone)]
 		pub enum $name { $(
 			$entry(Box<$entry>),
 		)* }

--- a/src/document_tree/elements.rs
+++ b/src/document_tree/elements.rs
@@ -26,7 +26,7 @@ pub trait Element {
 	fn classes_mut(&mut self) -> &mut Vec<String>;
 }
 
-#[derive(Debug,Default,PartialEq,Serialize)]
+#[derive(Debug,Default,PartialEq,Serialize,Clone)]
 pub struct CommonAttributes {
 	#[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
 	ids: Vec<ID>,
@@ -82,7 +82,7 @@ macro_rules! impl_new {(
 	),* $(,)* }
 ) => (
 	$(#[$attr])*
-	#[derive(Debug,PartialEq,Serialize)]
+	#[derive(Debug,PartialEq,Serialize,Clone)]
 	pub struct $name { $( 
 		$(#[$fattr])* $field: $typ,
 	)* }

--- a/src/document_tree/extra_attributes.rs
+++ b/src/document_tree/extra_attributes.rs
@@ -12,7 +12,7 @@ pub trait ExtraAttributes<A> {
 macro_rules! impl_extra {
 	( $name:ident { $( $(#[$pattr:meta])* $param:ident : $type:ty ),* $(,)* } ) => (
 		impl_extra!(
-			#[derive(Default,Debug,PartialEq,Serialize)]
+			#[derive(Default,Debug,PartialEq,Serialize,Clone)]
 			$name { $( $(#[$pattr])* $param : $type, )* }
 		);
 	);
@@ -41,7 +41,7 @@ impl_extra!(Target {
 	anonymous: bool,
 });
 impl_extra!(Raw { space: FixedSpace, format: Vec<NameToken> });
-impl_extra!(#[derive(Debug,PartialEq,Serialize)] Image {
+impl_extra!(#[derive(Debug,PartialEq,Serialize,Clone)] Image {
 	uri: target::Target,
 	align: Option<AlignHV>,
 	alt: Option<String>,

--- a/src/target.rs
+++ b/src/target.rs
@@ -7,7 +7,7 @@ use url::{self,Url};
 use serde_derive::Serialize;
 
 
-#[derive(Debug,PartialEq,Serialize)]
+#[derive(Debug,PartialEq,Serialize,Clone)]
 #[serde(untagged)]
 pub enum Target {
 	#[serde(serialize_with = "serialize_url")]


### PR DESCRIPTION
This is a prerequisite for #7, since a substitution definition can be referenced multiple times.