### PR TITLE
Decrement renderer level after section recursion

### DIFF
--- a/renderer/src/html.rs
+++ b/renderer/src/html.rs
@@ -151,6 +151,7 @@ impl HTMLRender for e::Section {
 			writeln!(renderer.stream)?;
 		}
 		write!(renderer.stream, "</section>")?;
+		renderer.level -= 1;
 		Ok(())
 	}
 }

--- a/renderer/src/html/tests.rs
+++ b/renderer/src/html/tests.rs
@@ -180,6 +180,55 @@ And even more stuff
 }
 
 #[test]
+fn many_sections() {
+	check_renders_to("\
++++++++++
+heading 1
++++++++++
+
+heading 2
+=========
+
+First stuff
+
+heading 2a
+----------
+
+First detail
+
+heading 3
+=========
+
+Second stuff
+
+heading 3a
+----------
+
+Second detail
+", "\
+<section id=\"heading-1\">
+<h1>heading 1</h1>
+<section id=\"heading-2\">
+<h2>heading 2</h2>
+<p>First stuff</p>
+<section id=\"heading-2a\">
+<h3>heading 2a</h3>
+<p>First detail</p>
+</section>
+</section>
+<section id=\"heading-3\">
+<h2>heading 3</h2>
+<p>Second stuff</p>
+<section id=\"heading-3a\">
+<h3>heading 3a</h3>
+<p>Second detail</p>
+</section>
+</section>
+</section>\
+");
+}
+
+#[test]
 fn bullet_list() {
 	check_renders_to("\
 * bullet


### PR DESCRIPTION
The html renderer section level used for title numbering is incremented
when entering a new section so that subsections get correct heading
elements. Match the increment with a decrement after having rendered the
section contents, so that multiple consecutive sections would stay
consistent.

Add a test to verify this behaviour.

Without the fix, the test would fail as follows:

    Diff < left / right > :
    <"<section id=\"heading-1\">\n<h1>heading 1</h1>\n<section id=\"heading-2\">\n<h2>heading 2</h2>\n<p>First stuff</p>\n<section id=\"heading-2a\">\n<h3>heading 2a</h3>\n<p>First detail</p>\n</section>\n</section>\n<section id=\"heading-3\">\n<h4>heading 3</h4>\n<p>Second stuff</p>\n<section id=\"heading-3a\">\n<h5>heading 3a</h5>\n<p>Second detail</p>\n</section>\n</section>\n</section>"
    >"<section id=\"heading-1\">\n<h1>heading 1</h1>\n<section id=\"heading-2\">\n<h2>heading 2</h2>\n<p>First stuff</p>\n<section id=\"heading-2a\">\n<h3>heading 2a</h3>\n<p>First detail</p>\n</section>\n</section>\n<section id=\"heading-3\">\n<h2>heading 3</h2>\n<p>Second stuff</p>\n<section id=\"heading-3a\">\n<h3>heading 3a</h3>\n<p>Second detail</p>\n</section>\n</section>\n</section>"

Note the h4 and h5 for the second stuff and detail.