### PR TITLE
Add support for raw directives

### DIFF
--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -16,6 +16,7 @@ hanging_block = _{
     substitution_def
     | image_directive
     | code_directive
+    | raw_directive
     | admonition
     | admonition_gen
     | target
@@ -90,6 +91,17 @@ source = { (!NEWLINE ~ ANY)+ }
 code_block = { code_line ~ (code_line_blank* ~ PEEK[..] ~ code_line)* }
 code_line_blank = { " "* ~ NEWLINE }
 code_line       = { (!NEWLINE ~ ANY)+ ~ NEWLINE }
+
+// Raw block. A directive
+
+raw_directive = {
+    ".." ~ PUSH(" "+) ~ "raw::" ~ " "+ ~ raw_output_format ~ NEWLINE ~
+    blank_line+ ~ PEEK[..-1] ~ PUSH("  " ~ POP) ~ raw_block ~ DROP
+}
+raw_output_format = { (!NEWLINE ~ ANY)+ }
+raw_block = { raw_line ~ (raw_line_blank* ~ PEEK[..] ~ raw_line)* }
+raw_line_blank = { " "* ~ NEWLINE }
+raw_line       = { (!NEWLINE ~ ANY)+ ~ NEWLINE }
 
 // Admonition. A directive. The generic one has a title
 

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -186,6 +186,45 @@ The end
 
 #[allow(clippy::cognitive_complexity)]
 #[test]
+fn raw() {
+	parses_to! {
+		parser: RstParser,
+		input: "\
+.. raw:: html
+
+   hello <span>world</span>
+
+.. raw:: html
+
+   hello <pre>world
+
+   parse</pre> this
+
+The end
+",
+		rule: Rule::document,
+		tokens: [
+			raw_directive(0, 43, [
+				raw_output_format(9, 13),
+				raw_block(18, 43, [
+					raw_line(18, 43),
+				]),
+			]),
+			raw_directive(44, 100, [
+				raw_output_format(53, 57),
+				raw_block(62, 100, [
+					raw_line(62, 79),
+					raw_line_blank(79, 80),
+					raw_line(83, 100),
+				]),
+			]),
+			paragraph(101, 108, [ str(101, 108) ]),
+		]
+	};
+}
+
+#[allow(clippy::cognitive_complexity)]
+#[test]
 fn substitutions() {
 	parses_to! {
 		parser: RstParser,

--- a/renderer/src/html.rs
+++ b/renderer/src/html.rs
@@ -11,6 +11,7 @@ use document_tree::{
 	elements as e,
 	extra_attributes as a,
 	element_categories as c,
+	attribute_types as at,
 };
 
 
@@ -238,8 +239,11 @@ impl HTMLRender for e::Target {
 
 impl HTMLRender for e::Raw {
 	fn render_html<W>(&self, renderer: &mut HTMLRenderer<W>) -> Result<(), Error> where W: Write {
-		for c in self.children() {
-			write!(renderer.stream, "{}", c)?;
+		let extra = self.extra();
+		if extra.format.contains(&at::NameToken("html".to_owned())) {
+			for c in self.children() {
+				write!(renderer.stream, "{}", c)?;
+			}
 		}
 		Ok(())
 	}

--- a/renderer/src/html/tests.rs
+++ b/renderer/src/html/tests.rs
@@ -241,6 +241,31 @@ fn code() {
 ");
 }
 
+#[test]
+fn raw_html() {
+	check_renders_to("\
+.. raw:: html
+
+   hello <span>world</span>
+   <p>paragraph
+
+   paragraph</p>
+
+after
+
+.. raw:: something_else
+
+   into a black hole this goes
+", "\
+hello <span>world</span>
+<p>paragraph
+
+paragraph</p>
+
+<p>after</p>\
+");
+}
+
 /*
 #[test]
 fn test_field_list() {


### PR DESCRIPTION
All content under a raw directive is rendered as-is if the output format matches the writer. Otherwise none of it is shown.

I don't know much how pest works or whether this has been meant to do in a specific way in rust-rst given the already existing bits such as elements::Raw, but at least this should get some discussion forward if anything?

Most of this stuff is borrowed from code directive parsing so there's some duplication. Suggestions welcome if that's too repetitive.

(Having `raw::` available early is helpful to work around other things that are missing from rust-rst.)