### PR TITLE
Add html test for substs in literals

### DIFF
--- a/document_tree/src/elements.rs
+++ b/document_tree/src/elements.rs
@@ -257,7 +257,7 @@ impl_elems!(
 	
 	//inline elements
 	(Emphasis,              TextOrInlineElement)
-	(Literal,               TextOrInlineElement)
+	(Literal,               String)
 	(Reference,             TextOrInlineElement; +)
 	(Strong,                TextOrInlineElement)
 	(FootnoteReference,     TextOrInlineElement; +)

--- a/parser/src/conversion/inline.rs
+++ b/parser/src/conversion/inline.rs
@@ -25,7 +25,7 @@ pub fn convert_inline(pair: Pair<Rule>) -> Result<c::TextOrInlineElement, Error>
 		Rule::substitution_name => convert_substitution_ref(pair)?.into(),
 		Rule::emph              => e::Emphasis::with_children(convert_inlines(pair)?).into(),
 		Rule::strong            => e::Strong::with_children(convert_inlines(pair)?).into(),
-		Rule::literal           => e::Literal::with_children(convert_inlines(pair)?).into(),
+		Rule::literal           => e::Literal::with_children(vec![pair.as_str().to_owned()]).into(),
 		rule => unimplemented!("unknown rule {:?}", rule),
 	})
 }

--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -135,7 +135,7 @@ str = { (!(NEWLINE | inline_special) ~ ANY)+ }
 // simple formatting
 inline_nested = _{ inline_special | str_nested }
 str_nested    =  { word_nested ~ ( " "+ ~ word_nested)* }
-// TODO: allow ` in emph and * in literal
+// TODO: allow ` in emph
 word_nested   = _{ (!(NEWLINE | " " | inline_special | "*" | "`") ~ ANY)+ }
 
 emph_outer    = _{ "*" ~ emph ~ "*" }
@@ -143,7 +143,7 @@ emph          =  { (!("*"|" ") ~ inline_nested)+ ~ (" "+ ~ (!("*"|" ") ~ inline_
 strong_outer  = _{ "**" ~ strong ~ "**" }
 strong        =  { (!("*"|" ") ~ inline_nested)+ ~ (" "+ ~ (!("*"|" ") ~ inline_nested)+)* }
 literal_outer = _{ "``" ~ literal ~ "``" }
-literal       =  { (!("`"|" ") ~ inline_nested)+ ~ (" "+ ~ (!("`"|" ") ~ inline_nested)+)* }
+literal       =  { (!"``" ~ ANY)+ }
 
 // inline links
 reference = { reference_target | reference_explicit | reference_auto }

--- a/parser/src/simplify.rs
+++ b/parser/src/simplify.rs
@@ -325,7 +325,7 @@ impl ResolvableRefs for c::TextOrInlineElement {
 			String(_) => {},
 			Emphasis(e) => sub_pop(&**e, refs),
 			Strong(e) => sub_pop(&**e, refs),
-			Literal(e) => sub_pop(&**e, refs),
+			Literal(_) => {},
 			Reference(e) => sub_pop(&**e, refs),
 			FootnoteReference(e) => sub_pop(&**e, refs),
 			CitationReference(e) => sub_pop(&**e, refs),
@@ -352,7 +352,7 @@ impl ResolvableRefs for c::TextOrInlineElement {
 			String(e) => String(e),
 			Emphasis(e) => sub_res(*e, refs).into(),
 			Strong(e) => sub_res(*e, refs).into(),
-			Literal(e) => sub_res(*e, refs).into(),
+			Literal(e) => Literal(e),
 			Reference(mut e) => {
 				if e.extra().refuri.is_none() {
 					if let Some(uri) = refs.target_url(&e.extra().refname) {

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -111,7 +111,7 @@ fn inline_code_literal_with_underscore() {
         input: "``NAME_WITH_UNDERSCORE``",
         rule: Rule::inline,
         tokens: [
-            literal(2, 22, [str_nested(2, 22)]),
+            literal(2, 22),
         ]
     };
 }
@@ -213,6 +213,23 @@ A |subst| in-line
 					str(75, 86), ws_newline(86, 87),
 					str(88, 100),
 				]) ]),
+			]),
+		]
+	};
+}
+
+#[test]
+fn substitution_in_literal() {
+	parses_to! {
+		parser: RstParser,
+		input: "Just ``|code|``, really ``*code* |only|``",
+		rule: Rule::document,
+		tokens: [
+			paragraph(0, 41, [
+				str(0, 5),
+				literal(7, 13),
+				str(15, 24),
+				literal(26, 39),
 			]),
 		]
 	};

--- a/renderer/src/html/tests.rs
+++ b/renderer/src/html/tests.rs
@@ -81,6 +81,20 @@ A |subst|.
 ", "<p>A text substitution.</p>");
 }
 
+#[test]
+fn not_substitution_literal() {
+	check_renders_to("\
+hello ``foo.map(|world| world + 42)``
+
+.. |world| replace:: something different
+
+.. code::
+
+   foo.map(|world| world + 42)
+", "<p>hello <code>foo.map(|world| world + 42)</code></p>
+<pre>foo.map(|world| world + 42)\n</pre>");
+}
+
 /*
 #[test]
 fn test_section_hierarchy() {


### PR DESCRIPTION
Text inside an inline or block literal that looks like a substitution reference must still stay unmodified.

This currently fails because the substitution is processed for the inline literal:

    Diff < left / right > :
    <"<p>hello <code>foo.map(something differentworld + 42)</code></p>\n<pre>foo.map(|world| world + 42)\n</pre>"
    >"<p>hello <code>foo.map(|world| world + 42)</code></p>\n<pre>foo.map(|world| world + 42)\n</pre>"
