### PR TITLE
Add support for parsing comments

### DIFF
--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -20,6 +20,9 @@ hanging_block = _{
     | admonition
     | admonition_gen
     | target
+    // Comments should be below the directives to try to match them first, but
+    // above the title that will interpret ".." as a title marker.
+    | block_comment
     | title
     | bullet_list
     | paragraph
@@ -110,6 +113,15 @@ admonition_gen     =  { ".." ~ PUSH(" "+) ~  admonition_type ~ "::" ~ (blank_lin
 admonition_type    =  { ^"attention" | ^"caution" | ^"danger" | ^"error" | ^"hint" | ^"important" | ^"note" | ^"tip" | ^"warning" }
 admonition_content = _{ PEEK[..-1] ~ PUSH("  " ~ POP) ~ hanging_block ~ block* } //TODO: merge with other directives?
 
+// Comments.
+
+block_comment   = {
+    ".." ~ PUSH(" "*) ~ comment_title? ~ NEWLINE? ~ comment_block? ~ (" "* ~ NEWLINE)* ~ DROP
+}
+comment_title = { (!NEWLINE ~ ANY)+ }
+comment_block = { (comment_line_blank* ~ PEEK[..] ~ comment_line)+ }
+comment_line_blank = { " "* ~ NEWLINE }
+comment_line       = { " "+ ~ (!NEWLINE ~ ANY)+ ~ NEWLINE }
 
 
 /*

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -225,6 +225,76 @@ The end
 
 #[allow(clippy::cognitive_complexity)]
 #[test]
+fn comments() {
+	parses_to! {
+		parser: RstParser,
+		input: "\
+.. This is a comment
+
+..
+   This as well.
+
+..
+   _so: is this!
+..
+   [and] this!
+..
+   this:: too!
+..
+   |even| this:: !
+.. With a title..
+
+   and a blank line...
+   followed by a non-blank line
+
+   and another one.
+",
+		rule: Rule::document,
+		tokens: [
+			block_comment(0, 22, [
+				comment_title(3, 20),
+			]),
+			block_comment(22, 43, [
+				comment_block(25, 42, [
+					comment_line(25, 42),
+				])
+			]),
+			block_comment(43, 63, [
+				comment_block(46, 63, [
+					comment_line(46, 63),
+				])
+			]),
+			block_comment(63, 81, [
+				comment_block(66, 81, [
+					comment_line(66, 81),
+				])
+			]),
+			block_comment(81, 99, [
+				comment_block(84, 99, [
+					comment_line(84, 99),
+				])
+			]),
+			block_comment(99, 121, [
+				comment_block(102, 121, [
+					comment_line(102, 121),
+				])
+			]),
+			block_comment(121, 216, [
+				comment_title(124, 138),
+				comment_block(139, 216, [
+					comment_line_blank(139, 140),
+					comment_line(141, 163),
+					comment_line(164, 195),
+					comment_line_blank(195, 196),
+					comment_line(197, 216),
+				])
+			]),
+		]
+	};
+}
+
+#[allow(clippy::cognitive_complexity)]
+#[test]
 fn substitutions() {
 	parses_to! {
 		parser: RstParser,


### PR DESCRIPTION
I pulled the examples from the RST specification.

A couple of notes: I'm choosing to ignore extra blank lines after a comment. Is the objective to have a parser that can give the exact same output as the input, or just semantically the same?

Also, what are the next steps to add support for comments in the parser?