### PR TITLE
Initial options impl

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+// Unter https://go.microsoft.com/fwlink/?LinkId=733558
+// finden Sie Informationen zum Format von "tasks.json"
+    "version": "2.0.0",
+    "tasks": [
+		{
+			"type": "cargo",
+			"subcommand": "test",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/renderer/src/html.rs
+++ b/renderer/src/html.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use failure::Error;
 
 // use crate::url::Url;
-use crate::opt::{RenderOptionsStandalone, RenderOptionsStandaloneBuilder};
+use crate::opt::{RenderOptionsStandalone, RenderOptionsBuilder, RenderOptionsStandaloneBuilder};
 use document_tree::{
 	Document,Element,HasChildren,ExtraAttributes,
 	elements as e,
@@ -21,8 +21,8 @@ use document_tree::{
 pub fn render_html<W, O>(document: &Document, stream: W, opts: O) -> Result<(), Error>
 	where W: Write, O: Into<RenderOptionsStandalone>
 {
-	let mut renderer = HTMLRenderer { stream, level: 0 };
 	let opts = opts.into();
+	let mut renderer = HTMLRenderer { stream, level: opts.initial_header_level() };
 	if opts.standalone() {
 		document.render_html(&mut renderer)
 	} else {

--- a/renderer/src/html.rs
+++ b/renderer/src/html.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use failure::Error;
 
 // use crate::url::Url;
+use crate::opt::{RenderOptionsStandalone, RenderOptionsStandaloneBuilder};
 use document_tree::{
 	Document,Element,HasChildren,ExtraAttributes,
 	elements as e,
@@ -17,9 +18,12 @@ use document_tree::{
 
 // static FOOTNOTE_SYMBOLS: [char; 10] = ['*', '†', '‡', '§', '¶', '#', '♠', '♥', '♦', '♣'];
 
-pub fn render_html<W>(document: &Document, stream: W, standalone: bool) -> Result<(), Error> where W: Write {
+pub fn render_html<W, O>(document: &Document, stream: W, opts: O) -> Result<(), Error>
+	where W: Write, O: Into<RenderOptionsStandalone>
+{
 	let mut renderer = HTMLRenderer { stream, level: 0 };
-	if standalone {
+	let opts = opts.into();
+	if opts.standalone() {
 		document.render_html(&mut renderer)
 	} else {
 		for c in document.children() {

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -1,4 +1,5 @@
 mod html;
+mod opt;
 
 
 use std::io::Write;

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -1,5 +1,5 @@
 mod html;
-mod opt;
+pub mod opt;
 
 
 use std::io::Write;

--- a/renderer/src/opt.rs
+++ b/renderer/src/opt.rs
@@ -1,0 +1,93 @@
+pub struct RenderOptions {
+	initial_header_level: u8,
+}
+
+impl Default for RenderOptions {
+	fn default() -> Self {
+		RenderOptions {
+			initial_header_level: 0,
+		}
+	}
+}
+
+pub trait RenderOptionsBuilder {
+	fn initial_header_level(&self) -> u8;
+	fn with_initial_header_level(&mut self, lvl: u8) -> &mut Self;
+}
+
+impl RenderOptionsBuilder for RenderOptions {
+	fn initial_header_level(&self) -> u8 {
+		self.initial_header_level
+	}
+	fn with_initial_header_level(&mut self, lvl: u8) -> &mut Self {
+		self.initial_header_level = lvl;
+		self
+	}
+}
+
+// standalone document formats
+
+pub struct RenderOptionsStandalone {
+	render_options: RenderOptions,
+	standalone: bool,
+}
+
+impl Default for RenderOptionsStandalone {
+	fn default() -> Self {
+		RenderOptionsStandalone {
+			render_options: Default::default(),
+			standalone: true,
+		}
+	}
+}
+
+pub trait RenderOptionsStandaloneBuilder {
+	fn into_render_options(self) -> RenderOptions;
+	fn render_options(&self) -> &RenderOptions;
+	fn render_options_mut(&mut self) -> &mut RenderOptions;
+	fn standalone(&self) -> bool;
+	fn with_standalone(&mut self, standalone: bool) -> &mut Self;
+}
+
+impl<T> RenderOptionsBuilder for T where T: RenderOptionsStandaloneBuilder {
+	fn initial_header_level(&self) -> u8 {
+		self.render_options().initial_header_level()
+	}
+	fn with_initial_header_level(&mut self, lvl: u8) -> &mut Self {
+		self.render_options_mut().with_initial_header_level(lvl);
+		self
+	}
+}
+
+impl RenderOptionsStandaloneBuilder for RenderOptionsStandalone {
+	fn into_render_options(self) -> RenderOptions {
+		self.render_options
+	}
+	fn render_options(&self) -> &RenderOptions {
+		&self.render_options
+	}
+	fn render_options_mut(&mut self) -> &mut RenderOptions {
+		&mut self.render_options
+	}
+	fn standalone(&self) -> bool {
+		self.standalone
+	}
+	fn with_standalone(&mut self, standalone: bool) -> &mut Self {
+		self.standalone = standalone;
+		self
+	}
+}
+
+impl From<bool> for RenderOptionsStandalone {
+	fn from(standalone: bool) -> Self {
+		let mut r: RenderOptionsStandalone = Default::default();
+		r.with_standalone(standalone);
+		r
+	}
+}
+
+impl<T> From<T> for RenderOptions where T: RenderOptionsStandaloneBuilder {
+	fn from(opts: T) -> Self {
+		opts.into_render_options()
+	}
+}


### PR DESCRIPTION
TODO:

- docs
- design: is this a good pattern or should they not be their own builders?
- make XML and JSON take and use RenderOptions? (initial header level)
- make XML use standalone option