### PR TITLE
chore: release

### DIFF
--- a/document_tree/CHANGELOG.md
+++ b/document_tree/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.0...document_tree-v0.4.1) - 2023-12-28
+
+### Other
+- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))

--- a/document_tree/Cargo.toml
+++ b/document_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'document_tree'
-version = '0.4.0'
+version = "0.4.1"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2018'
 description = 'reStructuredText’s DocumentTree representation'

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.0...rst_parser-v0.4.1) - 2023-12-28
+
+### Other
+- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_parser'
-version = '0.4.0'
+version = "0.4.1"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2018'
 description = 'a reStructuredText parser'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = '0.4.0' }
+document_tree = { path = '../document_tree', version = "0.4.1" }
 
 pest = '2.1.2'
 pest_derive = '2.1.0'

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.0...rst_renderer-v0.4.1) - 2023-12-28
+
+### Other
+- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_renderer'
-version = '0.4.0'
+version = "0.4.1"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2018'
 description = 'a reStructuredText renderer'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = '0.4.0' }
+document_tree = { path = '../document_tree', version = "0.4.1" }
 
 failure = '0.1.6'
 serde_json = '1.0.44'

--- a/rst/CHANGELOG.md
+++ b/rst/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.0...rst-v0.4.1) - 2023-12-28
+
+### Other
+- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))

--- a/rst/Cargo.toml
+++ b/rst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst'
-version = '0.4.0'
+version = "0.4.1"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2018'
 description = 'a reStructuredText parser and renderer for the command line'
@@ -12,8 +12,8 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-rst_renderer = { path = '../renderer', version = '0.4.0' }
-rst_parser = { path = '../parser', version = '0.4.0' }
+rst_renderer = { path = '../renderer', version = "0.4.1" }
+rst_parser = { path = '../parser', version = "0.4.1" }
 
 quicli = '0.4.0'
 structopt = '0.2.15'


### PR DESCRIPTION
## 🤖 New release
* `document_tree`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rst_parser`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rst_renderer`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rst`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `document_tree`
<blockquote>

## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.0...document_tree-v0.4.1) - 2023-12-28

### Other
- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))
</blockquote>

## `rst_parser`
<blockquote>

## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.0...rst_parser-v0.4.1) - 2023-12-28

### Other
- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))
</blockquote>

## `rst_renderer`
<blockquote>

## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.0...rst_renderer-v0.4.1) - 2023-12-28

### Other
- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))
</blockquote>

## `rst`
<blockquote>

## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.0...rst-v0.4.1) - 2023-12-28

### Other
- Commit format changes ([#41](https://github.com/flying-sheep/rust-rst/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).