### PR TITLE
Handle images with multiple options

### DIFF
--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -89,7 +89,7 @@ replace = { ^"replace::" ~ " "* ~ paragraph }
 image_directive = _{ ".." ~ PUSH(" "+) ~ image ~ DROP }
 image           =  { ^"image::" ~ line ~ image_opt_block? }
 image_opt_block = _{ PEEK[..-1] ~ PUSH("  " ~ POP) ~ image_option ~ (PEEK[..] ~ image_option)* }
-image_option    =  {":" ~ image_opt_name ~ ":" ~ line }
+image_option    =  { ":" ~ image_opt_name ~ ":" ~ line }
 image_opt_name  =  { common_opt_name | "alt" | "height" | "width" | "scale" | "align" | "target" }
 
 // Code block. A directive that allows adding a language to a literal block

--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -88,8 +88,8 @@ replace = { ^"replace::" ~ " "* ~ paragraph }
 
 image_directive = _{ ".." ~ PUSH(" "+) ~ image ~ DROP }
 image           =  { ^"image::" ~ line ~ image_opt_block? }
-image_opt_block = _{ PEEK[..-1] ~ PUSH("  " ~ POP) ~ image_option } //TODO: merge with other directives?
-image_option    =  { ":" ~ image_opt_name ~ ":" ~ line }
+image_opt_block = _{ PEEK[..-1] ~ PUSH("  " ~ POP) ~ image_option ~ (PEEK[..] ~ image_option)* }
+image_option    =  {":" ~ image_opt_name ~ ":" ~ line }
 image_opt_name  =  { common_opt_name | "alt" | "height" | "width" | "scale" | "align" | "target" }
 
 // Code block. A directive that allows adding a language to a literal block

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -393,6 +393,36 @@ fn substitution_image() {
     };
 }
 
+#[allow(clippy::cognitive_complexity)]
+#[test]
+fn substitution_image_with_alt() {
+    parses_to! {
+        parser: RstParser,
+        input: "\
+.. |subst| image:: thing.png
+   :alt: A thing
+   :target: foo.html
+",
+        rule: Rule::document,
+        tokens: [
+            substitution_def(0, 67, [
+                substitution_name(4, 9),
+                image(11, 67, [
+                    line(18, 29, [ str(18, 28) ]),
+                    image_option(32, 46, [
+                        image_opt_name(33, 36),
+                        line(37, 46, [ str(37, 45) ]),
+                    ]),
+                    image_option(49, 67, [
+                        image_opt_name(50, 56),
+                        line(57, 67, [ str(57, 66) ]),
+                    ]),
+                ]),
+            ]),
+        ]
+    };
+}
+
 // TODO: test images
 
 #[allow(clippy::cognitive_complexity)]


### PR DESCRIPTION
Previously, only a single option was handled correctly with subsequent options being treated as regular text after the image. 

This PR fixes the parser so it handles e.g.:

```rst
.. |subst| image:: thing.png
   :alt: A thing
   :target: foo.html
```