### PR TITLE
Fix parsing of percentage in image scale attributes

### DIFF
--- a/parser/src/conversion/block.rs
+++ b/parser/src/conversion/block.rs
@@ -164,7 +164,7 @@ where
 fn parse_scale(pair: &Pair<Rule>) -> Result<u8, Error> {
     let input = pair.as_str().trim();
     let input = if let Some(percentage) = input.strip_suffix('%') {
-        percentage
+        percentage.trim_end()
     } else {
         input
     };

--- a/parser/src/conversion/block.rs
+++ b/parser/src/conversion/block.rs
@@ -162,10 +162,11 @@ where
 }
 
 fn parse_scale(pair: &Pair<Rule>) -> Result<u8, Error> {
-    let input = if pair.as_str().ends_with('%') {
-        &pair.as_str()[..pair.as_str().len() - 1]
+    let input = pair.as_str().trim();
+    let input = if let Some(percentage) = input.strip_suffix('%') {
+        percentage
     } else {
-        pair.as_str()
+        input
     };
     use pest::error::{Error, ErrorVariant};
     Ok(input.parse().map_err(|e: std::num::ParseIntError| {


### PR DESCRIPTION
Without this change, the tests fails if a % is included in a scale attribute:

```
---- conversion::tests::test_convert_image_scale stdout ----
thread 'conversion::tests::test_convert_image_scale' panicked at parser/src/conversion/tests.rs:117:76:
called `Result::unwrap()` on an `Err` value:  --> 2:11
  |
2 |    :scale: 90%␊
2 |

  |           ^---^
  |
  = invalid digit found in string
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```