### PR TITLE
Allow 4+ spaces of indentation for image options

### DIFF
--- a/parser/src/rst.pest
+++ b/parser/src/rst.pest
@@ -102,7 +102,7 @@ replace = { ^"replace::" ~ " "* ~ paragraph }
 
 image_directive = _{ ".." ~ PUSH(" "+) ~ image ~ DROP }
 image           =  { ^"image::" ~ line ~ image_opt_block? }
-image_opt_block = _{ PEEK[..-1] ~ PUSH("  " ~ POP) ~ image_option ~ (PEEK[..] ~ image_option)* }
+image_opt_block = _{ PUSH(" "+) ~ image_option ~ (PEEK ~ image_option)* ~ DROP }
 image_option    =  { ":" ~ image_opt_name ~ ":" ~ line }
 image_opt_name  =  { common_opt_name | "alt" | "height" | "width" | "scale" | "align" | "target" }
 

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -675,6 +675,32 @@ fn substitution_image_with_alt() {
     };
 }
 
+#[allow(clippy::cognitive_complexity)]
+#[test]
+fn substitution_image_with_many_indents() {
+    parses_to! {
+        parser: RstParser,
+        input: "\
+.. image:: thing.png
+    :target: foo.html
+.. image:: another.png
+",
+        rule: Rule::document,
+        tokens: [
+            image(3, 43, [
+                line(10, 21, [ str(10, 20) ]),
+                image_option(25, 43, [
+                    image_opt_name(26, 32),
+                    line(33, 43, [ str(33, 42) ]),
+                ]),
+            ]),
+            image(46, 66, [
+                line(53, 66, [ str(53, 65) ]),
+            ]),
+        ]
+    };
+}
+
 // TODO: test images
 
 #[allow(clippy::cognitive_complexity)]


### PR DESCRIPTION
Previously, this only supported 3.