### PR TITLE
chore: release v0.4.2

### DIFF
--- a/document_tree/CHANGELOG.md
+++ b/document_tree/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.1...document_tree-v0.4.2) - 2025-04-13
+
+### Other
+
+- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
+- Visitor ([#68](https://github.com/flying-sheep/rust-rst/pull/68))
+- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
+- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
+- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
+- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
+
 ## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.0...document_tree-v0.4.1) - 2024-11-20
 
 ### Other

--- a/document_tree/Cargo.toml
+++ b/document_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'document_tree'
-version = "0.4.1"
+version = "0.4.2"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'reStructuredText’s DocumentTree representation'

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.1...rst_parser-v0.4.2) - 2025-04-13
+
+### Other
+
+- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
+- Visitor ([#68](https://github.com/flying-sheep/rust-rst/pull/68))
+- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
+- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
+- Support block quote ([#61](https://github.com/flying-sheep/rust-rst/pull/61))
+- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
+- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
+
 ## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.0...rst_parser-v0.4.1) - 2024-11-20
 
 ### Other

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_parser'
-version = "0.4.1"
+version = "0.4.2"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText parser'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = "0.4.1" }
+document_tree = { path = '../document_tree', version = "0.4.2" }
 
 anyhow = '1.0.86'
 pest = '2.1.2'

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.1...rst_renderer-v0.4.2) - 2025-04-13
+
+### Other
+
+- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
+- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
+- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
+- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
+- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
+
 ## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.0...rst_renderer-v0.4.1) - 2024-11-20
 
 ### Other

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_renderer'
-version = "0.4.1"
+version = "0.4.2"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText renderer'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = "0.4.1" }
+document_tree = { path = '../document_tree', version = "0.4.2" }
 
 anyhow = '1.0.86'
 serde_json = '1.0.44'

--- a/rst/CHANGELOG.md
+++ b/rst/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.1...rst-v0.4.2) - 2025-04-13
+
+### Other
+
+- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
+- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
+- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
+
 ## [0.4.1](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.0...rst-v0.4.1) - 2024-11-20
 
 ### Other

--- a/rst/Cargo.toml
+++ b/rst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst'
-version = "0.4.1"
+version = "0.4.2"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText parser and renderer for the command line'
@@ -12,8 +12,8 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-rst_renderer = { path = '../renderer', version = "0.4.1" }
-rst_parser = { path = '../parser', version = "0.4.1" }
+rst_renderer = { path = '../renderer', version = "0.4.2" }
+rst_parser = { path = '../parser', version = "0.4.2" }
 
 anyhow = '1.0.86'
 clap = { version = '4', features = ['derive'] }


### PR DESCRIPTION



## 🤖 New release

* `document_tree`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `rst_parser`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `rst_renderer`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `rst`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `document_tree`

<blockquote>

## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.1...document_tree-v0.4.2) - 2025-04-13

### Other

- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
- Visitor ([#68](https://github.com/flying-sheep/rust-rst/pull/68))
- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
</blockquote>

## `rst_parser`

<blockquote>

## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.1...rst_parser-v0.4.2) - 2025-04-13

### Other

- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
- Visitor ([#68](https://github.com/flying-sheep/rust-rst/pull/68))
- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
- Support block quote ([#61](https://github.com/flying-sheep/rust-rst/pull/61))
- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
</blockquote>

## `rst_renderer`

<blockquote>

## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.1...rst_renderer-v0.4.2) - 2025-04-13

### Other

- Footnote refs ([#67](https://github.com/flying-sheep/rust-rst/pull/67))
- Footnotes ([#65](https://github.com/flying-sheep/rust-rst/pull/65))
- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
</blockquote>

## `rst`

<blockquote>

## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.1...rst-v0.4.2) - 2025-04-13

### Other

- clippy ([#66](https://github.com/flying-sheep/rust-rst/pull/66))
- bump edition again ([#64](https://github.com/flying-sheep/rust-rst/pull/64))
- Clippy ([#62](https://github.com/flying-sheep/rust-rst/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).