### PR TITLE
chore: release

### DIFF
--- a/document_tree/CHANGELOG.md
+++ b/document_tree/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.2...document_tree-v0.5.0) - 2026-01-21
+
+### Other
+
+- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
+- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
+
 ## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.1...document_tree-v0.4.2) - 2025-04-13
 
 ### Other

--- a/document_tree/Cargo.toml
+++ b/document_tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'document_tree'
-version = "0.4.2"
+version = "0.5.0"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'reStructuredText’s DocumentTree representation'

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.2...rst_parser-v0.4.3) - 2026-01-21
+
+### Other
+
+- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
+- [pre-commit.ci] pre-commit autoupdate ([#73](https://github.com/flying-sheep/rust-rst/pull/73))
+- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
+
 ## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.1...rst_parser-v0.4.2) - 2025-04-13
 
 ### Other

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_parser'
-version = "0.4.2"
+version = "0.4.3"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText parser'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = "0.4.2" }
+document_tree = { path = '../document_tree', version = "0.5.0" }
 
 anyhow = '1.0.86'
 pest = '2.1.2'

--- a/renderer/CHANGELOG.md
+++ b/renderer/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.2...rst_renderer-v0.4.3) - 2026-01-21
+
+### Other
+
+- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
+- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
+- Better HTML ([#69](https://github.com/flying-sheep/rust-rst/pull/69))
+
 ## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.1...rst_renderer-v0.4.2) - 2025-04-13
 
 ### Other

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst_renderer'
-version = "0.4.2"
+version = "0.4.3"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText renderer'
@@ -12,7 +12,7 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-document_tree = { path = '../document_tree', version = "0.4.2" }
+document_tree = { path = '../document_tree', version = "0.5.0" }
 
 anyhow = '1.0.86'
 serde_json = '1.0.44'

--- a/rst/CHANGELOG.md
+++ b/rst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.2...rst-v0.4.3) - 2026-01-21
+
+### Other
+
+- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
+
 ## [0.4.2](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.1...rst-v0.4.2) - 2025-04-13
 
 ### Other

--- a/rst/Cargo.toml
+++ b/rst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'rst'
-version = "0.4.2"
+version = "0.4.3"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'a reStructuredText parser and renderer for the command line'
@@ -12,8 +12,8 @@ homepage = 'https://github.com/flying-sheep/rust-rst'
 repository = 'https://github.com/flying-sheep/rust-rst'
 
 [dependencies]
-rst_renderer = { path = '../renderer', version = "0.4.2" }
-rst_parser = { path = '../parser', version = "0.4.2" }
+rst_renderer = { path = '../renderer', version = "0.4.3" }
+rst_parser = { path = '../parser', version = "0.4.3" }
 
 anyhow = '1.0.86'
 clap = { version = '4', features = ['derive'] }


### PR DESCRIPTION



## 🤖 New release

* `document_tree`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)
* `rst_parser`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `rst_renderer`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `rst`: 0.4.2 -> 0.4.3

### ⚠ `document_tree` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_missing.ron

Failed in:
  enum document_tree::attribute_types::AutoFootnoteType, previously in file /tmp/.tmpzfi6k6/document_tree/src/attribute_types.rs:19

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait document_tree::extra_attributes::FootnoteType, previously in file /tmp/.tmpzfi6k6/document_tree/src/extra_attributes.rs:109
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `document_tree`

<blockquote>

## [0.5.0](https://github.com/flying-sheep/rust-rst/compare/document_tree-v0.4.2...document_tree-v0.5.0) - 2026-01-21

### Other

- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
</blockquote>

## `rst_parser`

<blockquote>

## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst_parser-v0.4.2...rst_parser-v0.4.3) - 2026-01-21

### Other

- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
- [pre-commit.ci] pre-commit autoupdate ([#73](https://github.com/flying-sheep/rust-rst/pull/73))
- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
</blockquote>

## `rst_renderer`

<blockquote>

## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst_renderer-v0.4.2...rst_renderer-v0.4.3) - 2026-01-21

### Other

- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
- Refactor standard transform ([#71](https://github.com/flying-sheep/rust-rst/pull/71))
- Better HTML ([#69](https://github.com/flying-sheep/rust-rst/pull/69))
</blockquote>

## `rst`

<blockquote>

## [0.4.3](https://github.com/flying-sheep/rust-rst/compare/rst-v0.4.2...rst-v0.4.3) - 2026-01-21

### Other

- Schema ([#72](https://github.com/flying-sheep/rust-rst/pull/72))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).