### PR TITLE
Schema

### DIFF
--- a/document_tree/Cargo.toml
+++ b/document_tree/Cargo.toml
@@ -18,4 +18,4 @@ url = '2.1.0'
 serde = '1.0.104'
 serde_derive = '1.0.104'
 linearize = { version = "0.1.4", features = ["derive"] }
-schemars = "1.0.0-alpha.17"
+schemars = "1.0.0"

--- a/document_tree/Cargo.toml
+++ b/document_tree/Cargo.toml
@@ -18,3 +18,4 @@ url = '2.1.0'
 serde = '1.0.104'
 serde_derive = '1.0.104'
 linearize = { version = "0.1.4", features = ["derive"] }
+schemars = "1.0.0-alpha.17"

--- a/document_tree/src/attribute_types.rs
+++ b/document_tree/src/attribute_types.rs
@@ -97,6 +97,7 @@ pub struct TableGroupCols(pub usize);
 // no eq for f64
 #[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
 #[serde(tag = "unit", content = "value")]
+#[schemars(_unstable_ref_variants)]
 pub enum Measure {
     // https://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#length-units
     Em(f64),

--- a/document_tree/src/attribute_types.rs
+++ b/document_tree/src/attribute_types.rs
@@ -3,11 +3,12 @@ use std::str::FromStr;
 use anyhow::{Error, bail, format_err};
 use linearize::Linearize;
 use regex::Regex;
+use schemars::JsonSchema;
 use serde_derive::Serialize;
 
 use crate::url::Url;
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum EnumeratedListType {
     Arabic,
     LowerAlpha,
@@ -16,7 +17,7 @@ pub enum EnumeratedListType {
     UpperRoman,
 }
 
-#[derive(Linearize, Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Linearize, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum FootnoteType {
     Number,
     Symbol,
@@ -34,7 +35,7 @@ impl TryFrom<char> for FootnoteType {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum FixedSpace {
     Default,
     // yes, default really is not “Default”
@@ -42,13 +43,13 @@ pub enum FixedSpace {
     Preserve,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum AlignH {
     Left,
     Center,
     Right,
 }
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum AlignHV {
     Top,
     Middle,
@@ -57,14 +58,14 @@ pub enum AlignHV {
     Center,
     Right,
 }
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum AlignV {
     Top,
     Middle,
     Bottom,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum TableAlignH {
     Left,
     Right,
@@ -72,7 +73,7 @@ pub enum TableAlignH {
     Justify,
     Char,
 }
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub enum TableBorder {
     Top,
     Bottom,
@@ -82,19 +83,20 @@ pub enum TableBorder {
     None,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub struct ID(pub String);
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub struct NameToken(pub String);
 
 // The table DTD has the cols attribute of tgroup as required, but having
 // TableGroupCols not implement Default would leave no possible implementation
 // for TableGroup::with_children.
-#[derive(Default, Debug, PartialEq, Eq, Hash, Serialize, Clone)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, JsonSchema)]
 pub struct TableGroupCols(pub usize);
 
 // no eq for f64
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
+#[serde(tag = "unit", content = "value")]
 pub enum Measure {
     // https://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#length-units
     Em(f64),

--- a/document_tree/src/attribute_types.rs
+++ b/document_tree/src/attribute_types.rs
@@ -121,7 +121,7 @@ impl FromStr for AlignHV {
             "left" => A::Left,
             "center" => A::Center,
             "right" => A::Right,
-            s => bail!("Invalid Alignment {}", s),
+            s => bail!("Invalid Alignment {s}"),
         })
     }
 }

--- a/document_tree/src/element_categories.rs
+++ b/document_tree/src/element_categories.rs
@@ -36,18 +36,25 @@ macro_rules! impl_into {
 }
 
 macro_rules! synonymous_enum {
-    ( $subcat:ident : $($supcat:ident),+ ; $midcat:ident : $supsupcat:ident { $($entry:ident),+ $(,)* } ) => {
-        synonymous_enum!($subcat : $( $supcat ),+ , $midcat { $($entry,)* });
+    ( $subcat:ident : $($supcat:ident),+ ; $midcat:ident : $supsupcat:ident {
+        $($(#[$attr:meta])? $entry:ident),+ $(,)*
+    } ) => {
+        synonymous_enum!($subcat : $( $supcat ),+ , $midcat { $($(#[$attr])? $entry,)+ });
         $( impl_into!($midcat::$entry => $supsupcat); )+
     };
-    ( $subcat:ident : $($supcat:ident),+ { $($entry:ident),+ $(,)* } ) => {
-        synonymous_enum!($subcat { $( $entry, )* });
+    ( $subcat:ident : $($supcat:ident),+ {
+        $($(#[$attr:meta])? $entry:ident),+ $(,)*
+    } ) => {
+        synonymous_enum!($subcat { $($(#[$attr])? $entry,)* });
         cartesian!(impl_into, [ $( ($subcat::$entry) ),+ ], [ $($supcat),+ ]);
     };
-    ( $name:ident { $( $entry:ident ),+ $(,)* } ) => {
+    ( $name:ident {
+        $($(#[$attr:meta])? $entry:ident),+ $(,)*
+    } ) => {
         #[derive(Clone, PartialEq, Serialize, JsonSchema)]
         #[serde(tag = "type")]
         pub enum $name { $(
+            $(#[$attr])?
             $entry(Box<$entry>),
         )* }
 
@@ -72,9 +79,12 @@ synonymous_enum!(StructuralSubElement {
     Subtitle,
     Decoration,
     Docinfo,
+    #[serde(untagged)]
     SubStructure
 });
-synonymous_enum!(SubStructure: StructuralSubElement { Topic, Sidebar, Transition, Section, BodyElement });
+synonymous_enum!(SubStructure: StructuralSubElement {
+    Topic, Sidebar, Transition, Section, #[serde(untagged)] BodyElement
+});
 synonymous_enum!(BodyElement: SubTopic, SubSidebar, SubBlockQuote, SubFootnote, SubFigure; SubStructure: StructuralSubElement {
     //Simple
     Paragraph, LiteralBlock, DoctestBlock, MathBlock, Rubric, SubstitutionDefinition, Comment, Pending, Target, Raw, Image,

--- a/document_tree/src/element_categories.rs
+++ b/document_tree/src/element_categories.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug, Formatter};
 
+use schemars::JsonSchema;
 use serde_derive::Serialize;
 
 #[allow(clippy::wildcard_imports)]
@@ -44,7 +45,8 @@ macro_rules! synonymous_enum {
         cartesian!(impl_into, [ $( ($subcat::$entry) ),+ ], [ $($supcat),+ ]);
     };
     ( $name:ident { $( $entry:ident ),+ $(,)* } ) => {
-        #[derive(PartialEq,Serialize,Clone)]
+        #[derive(Clone, PartialEq, Serialize, JsonSchema)]
+        #[serde(tag = "type")]
         pub enum $name { $(
             $entry(Box<$entry>),
         )* }

--- a/document_tree/src/element_categories.rs
+++ b/document_tree/src/element_categories.rs
@@ -53,6 +53,7 @@ macro_rules! synonymous_enum {
     } ) => {
         #[derive(Clone, PartialEq, Serialize, JsonSchema)]
         #[serde(tag = "type")]
+        #[schemars(_unstable_ref_variants)]
         pub enum $name { $(
             $(#[$attr])?
             $entry(Box<$entry>),

--- a/document_tree/src/elements.rs
+++ b/document_tree/src/elements.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde_derive::Serialize;
 use std::path::PathBuf;
 
@@ -26,7 +27,7 @@ pub trait Element {
     fn classes_mut(&mut self) -> &mut Vec<String>;
 }
 
-#[derive(Debug, Default, PartialEq, Serialize, Clone)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, JsonSchema)]
 pub struct CommonAttributes {
     #[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
     ids: Vec<ID>,
@@ -128,7 +129,7 @@ macro_rules! impl_new {(
     ),* $(,)* }
 ) => (
     $(#[$attr])*
-    #[derive(Debug,PartialEq,Serialize,Clone)]
+    #[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
     pub struct $name { $(
         $(#[$fattr])* $field: $typ,
     )* }
@@ -208,7 +209,7 @@ macro_rules! impl_elems { ( $( ($($args:tt)*) )* ) => (
     $( impl_elem!($($args)*); )*
 )}
 
-#[derive(Default, Debug, Serialize)]
+#[derive(Default, Debug, Serialize, JsonSchema)]
 pub struct Document {
     children: Vec<StructuralSubElement>,
 }

--- a/document_tree/src/elements.rs
+++ b/document_tree/src/elements.rs
@@ -29,13 +29,13 @@ pub trait Element {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, JsonSchema)]
 pub struct CommonAttributes {
-    #[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
+    #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
     ids: Vec<ID>,
-    #[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
+    #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
     names: Vec<NameToken>,
-    #[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
+    #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
     source: Option<PathBuf>,
-    #[serde(skip_serializing_if = "CanBeEmpty::is_empty")]
+    #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
     classes: Vec<String>,
     //TODO: dupnames
 }
@@ -182,6 +182,7 @@ macro_rules! impl_elem {
             pub struct $name {
                 #[serde(flatten)]
                 common: CommonAttributes,
+                #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
                 children: Vec<$childtype>,
             }
         );
@@ -196,6 +197,7 @@ macro_rules! impl_elem {
                 common: CommonAttributes,
                 #[serde(flatten)]
                 extra: extra_attributes::$name,
+                #[serde(default, skip_serializing_if = "CanBeEmpty::is_empty")]
                 children: Vec<$childtype>,
             }
         );

--- a/document_tree/src/extra_attributes.rs
+++ b/document_tree/src/extra_attributes.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde_derive::Serialize;
 
 use crate::attribute_types::{
@@ -16,7 +17,7 @@ pub trait ExtraAttributes<A> {
 macro_rules! impl_extra {
     ( $name:ident { $( $(#[$pattr:meta])* $param:ident : $type:ty ),* $(,)* } ) => (
         impl_extra!(
-            #[derive(Default,Debug,PartialEq,Serialize,Clone)]
+            #[derive(Clone, Default, Debug, PartialEq, Serialize, JsonSchema)]
             $name { $( $(#[$pattr])* $param : $type, )* }
         );
     );
@@ -48,7 +49,7 @@ impl_extra!(Target {
     anonymous: bool,
 });
 impl_extra!(Raw { space: FixedSpace, format: Vec<NameToken> });
-impl_extra!(#[derive(Debug,PartialEq,Serialize,Clone)] Image {
+impl_extra!(#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)] Image {
     uri: Url,
     align: Option<AlignHV>,
     alt: Option<String>,

--- a/document_tree/src/url.rs
+++ b/document_tree/src/url.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use schemars::JsonSchema;
 use serde_derive::Serialize;
 use url::{self, ParseError};
 
@@ -24,7 +25,7 @@ fn starts_with_scheme(input: &str) -> bool {
 
 /// The string representation of a URL, either absolute or relative, that has
 /// been verified as a valid URL on construction.
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Serialize, JsonSchema)]
 #[serde(transparent)]
 pub struct Url(String);
 

--- a/parser/src/conversion/block.rs
+++ b/parser/src/conversion/block.rs
@@ -189,7 +189,7 @@ where
             "scale" => image.extra_mut().scale = Some(parse_scale(&opt_val)?),
             "align" => image.extra_mut().align = Some(opt_val.parse()?),
             "target" => image.extra_mut().target = Some(opt_val.parse()?),
-            name => bail!("Unknown Image option {}", name),
+            name => bail!("Unknown Image option {name}"),
         }
     }
     Ok(image)

--- a/parser/src/pair_ext_parse.rs
+++ b/parser/src/pair_ext_parse.rs
@@ -8,7 +8,7 @@ pub trait PairExt<R>
 where
     R: pest::RuleType,
 {
-    fn parse<T, E>(&self) -> Result<T, Box<Error<R>>>
+    fn parse<T, E>(&self) -> Result<T, Error<R>>
     where
         T: FromStr<Err = E>,
         E: ToString;
@@ -18,7 +18,7 @@ impl<R> PairExt<R> for Pair<'_, R>
 where
     R: pest::RuleType,
 {
-    fn parse<T, E>(&self) -> Result<T, Box<Error<R>>>
+    fn parse<T, E>(&self) -> Result<T, Error<R>>
     where
         T: FromStr<Err = E>,
         E: ToString,
@@ -29,7 +29,7 @@ where
     }
 }
 
-pub(crate) fn to_parse_error<E, R>(span: Span, e: &E) -> Box<Error<R>>
+pub(crate) fn to_parse_error<E, R>(span: Span, e: &E) -> Error<R>
 where
     E: ToString,
     R: pest::RuleType,
@@ -37,5 +37,5 @@ where
     let var: ErrorVariant<R> = ErrorVariant::CustomError {
         message: e.to_string(),
     };
-    Box::new(Error::new_from_span(var, span))
+    Error::new_from_span(var, span)
 }

--- a/parser/src/transforms/standard.rs
+++ b/parser/src/transforms/standard.rs
@@ -380,10 +380,10 @@ impl Transform for Pass3<'_> {
         &mut self,
         mut e: e::Reference,
     ) -> impl Iterator<Item = c::TextOrInlineElement> {
-        if e.extra().refuri.is_none() {
-            if let Some(uri) = self.target_url(&e.extra().refname) {
-                e.extra_mut().refuri = Some(uri.clone());
-            }
+        if e.extra().refuri.is_none()
+            && let Some(uri) = self.target_url(&e.extra().refname)
+        {
+            e.extra_mut().refuri = Some(uri.clone());
         }
         once(e.into())
     }

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -17,6 +17,7 @@ document_tree = { path = '../document_tree', version = "0.4.2" }
 anyhow = '1.0.86'
 serde_json = '1.0.44'
 serde-xml-rs = '0.5'
+schemars = "1.0.0-alpha.17"
 
 [dev-dependencies]
 rst_parser = { path = '../parser' }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -47,6 +47,6 @@ where
     W: Write,
 {
     serde_xml_rs::to_writer(stream, &document)
-        .map_err(|e| anyhow!("Failed to serialize XML: {}", e))?;
+        .map_err(|e| anyhow!("Failed to serialize XML: {e}"))?;
     Ok(())
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -5,8 +5,11 @@ mod html;
 use std::io::Write;
 
 use anyhow::{Error, anyhow};
+use schemars::schema_for;
 
 use document_tree::Document;
+
+pub use html::render_html;
 
 /// Render a document tree as JSON.
 ///
@@ -18,6 +21,16 @@ where
 {
     serde_json::to_writer(stream, &document)?;
     Ok(())
+}
+
+#[expect(clippy::missing_panics_doc, reason = "infallible")]
+/// Render the JSON schema for [`document_tree::Document`].
+pub fn render_json_schema_document<W>(stream: W)
+where
+    W: Write,
+{
+    let schema = schema_for!(document_tree::Document);
+    serde_json::to_writer(stream, &schema).unwrap();
 }
 
 /// Render a document tree as XML.
@@ -32,5 +45,3 @@ where
         .map_err(|e| anyhow!("Failed to serialize XML: {}", e))?;
     Ok(())
 }
-
-pub use html::render_html;

--- a/rst/src/main.rs
+++ b/rst/src/main.rs
@@ -3,16 +3,31 @@
 use clap::Parser;
 
 use rst_parser::parse;
-use rst_renderer::{render_html, render_json, render_json_schema_document, render_xml};
+use rst_renderer::{
+    SchemaSettings, render_html, render_json, render_json_schema_document, render_xml,
+};
 
 use std::io::{self, Read};
 
 #[derive(Debug, Clone, clap::ValueEnum)]
-#[allow(non_camel_case_types)]
 enum Format {
-    json,
-    xml,
-    html,
+    Json,
+    Xml,
+    Html,
+}
+
+#[derive(Debug, Default, Clone, clap::ValueEnum)]
+enum SchemaVersion {
+    // tooling is hopelessly outdated, draft 7 is kind of the best bet
+    #[default]
+    #[value(name = "draft7")]
+    Draft07,
+    #[value(name = "2019-09")]
+    Draft2019_09,
+    #[value(name = "2020-12")]
+    Draft2020_12,
+    #[value(name = "openapi3")]
+    OpenApi3,
 }
 
 #[derive(Debug, Parser)]
@@ -25,14 +40,17 @@ struct Cli {
     #[command(flatten)]
     verbosity: clap_verbosity_flag::Verbosity,
     /// Print schema
-    #[arg(long)]
-    schema: bool,
+    #[arg(long, num_args = ..=1, require_equals = true, default_missing_value = "draft7")]
+    schema: Option<SchemaVersion>,
 }
 
 fn main() -> Result<(), anyhow::Error> {
     let args = Cli::parse();
 
-    let level_filter = args.verbosity.log_level().unwrap().to_level_filter();
+    let level_filter = args
+        .verbosity
+        .log_level()
+        .map_or(log::LevelFilter::Off, |l| l.to_level_filter());
     env_logger::Builder::new()
         .filter(Some("rst"), level_filter)
         .filter(None, log::Level::Warn.to_level_filter())
@@ -40,17 +58,23 @@ fn main() -> Result<(), anyhow::Error> {
 
     let stdout = std::io::stdout();
 
-    if args.schema {
-        render_json_schema_document(stdout);
+    if let Some(schema) = &args.schema {
+        let settings = match schema {
+            SchemaVersion::Draft07 => SchemaSettings::draft07(),
+            SchemaVersion::Draft2019_09 => SchemaSettings::draft2019_09(),
+            SchemaVersion::Draft2020_12 => SchemaSettings::draft2020_12(),
+            SchemaVersion::OpenApi3 => SchemaSettings::openapi3(),
+        };
+        render_json_schema_document(stdout, settings, level_filter.to_level().is_some());
         return Ok(());
     }
 
     let content = preprocess_content(args.file.as_deref())?;
     let document = parse(&content)?;
     match args.format {
-        Format::json => render_json(&document, stdout)?,
-        Format::xml => render_xml(&document, stdout)?,
-        Format::html => render_html(&document, stdout, true)?,
+        Format::Json => render_json(&document, stdout)?,
+        Format::Xml => render_xml(&document, stdout)?,
+        Format::Html => render_html(&document, stdout, true)?,
     }
     Ok(())
 }


### PR DESCRIPTION
To visualize the schema:

```nushell
(cargo run -- --schema
	| do { save -f target/schema.json; $in }
	| npx --package=json-schema-to-typescript json2ts --additionalProperties=false
	| save -f target/schema.d.ts)
npx http-server -p 9876 --cors -c-1
xdg-open 'https://json-schema.app/view/%23?url=http%3A%2F%2F127.0.0.1%3A9876%2Ftarget%2Fschema.json'
```


TODO:

- [x] figure out if it’s possible to get `json-schema-to-typescript` to merge the ref with the inline type
- [x] only use innermost tag: *done in schemars 1a19, and of course 1.0*

	json-schema-to-typescript creates
	
	```typescript
	export type StructuralSubElement = Title | Subtitle | Decoration | Docinfo | SubStructure;
	export type SubStructure = {  type: "SubStructure" } & (… | BodyElement);
	export type BodyElement = { type: "BodyElement" } & (…);
	```

	which makes no sense
